### PR TITLE
Live Push 2021-11-09: add insecure flag to the curl command (ssl)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL homepage="https://github.com/justia/ga-phplint-5.5"
 
 RUN apt-get update && apt-get -y install zip unzip && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sS https://getcomposer.org/installer | php -- \
+RUN curl -sS -k https://getcomposer.org/installer | php -- \
 --install-dir=/usr/bin --filename=composer && chmod +x /usr/bin/composer
 
 RUN mkdir /phplint && cd /phplint && composer require overtrue/phplint && ln -s /phplint/vendor/bin/phplint /usr/local/bin/phplint


### PR DESCRIPTION
## General

Fixes this kind of errors: https://github.com/justia/internal-projects/runs/4148707815?check_suite_focus=true

### Code Refactoring

- Add insecure flag to the curl command (a76f4af8398ca28a428aca28099f7d333dd6bb0a)


